### PR TITLE
Improve relative path to binaries from wrapper scripts

### DIFF
--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ar "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ar "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ar "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ar "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ar "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ar
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ar "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-cpp "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-cpp "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-cpp "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-cpp "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-cpp "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-cpp
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-cpp "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcc "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcc "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcc "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcc "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcc "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcc
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcc "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcov "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcov "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcov "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcov "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcov "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-gcov
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-gcov "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ld "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ld "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ld "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ld "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ld "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-ld
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-ld "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-nm "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-nm "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-nm "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-nm "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-nm
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-nm "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-nm "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objcopy "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objcopy "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objcopy "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objcopy "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objcopy "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objcopy
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objcopy "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objdump "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objdump "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objdump "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objdump "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objdump "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-objdump
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-objdump "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../../"
+EXECROOT="$SCRIPT_DIR/../../../../../"
+cd "$EXECROOT"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-strip "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-strip "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-strip "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../../../../"
+cd "$SCRIPT_DIR/../../../../../"
 external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-strip "$@"

--- a/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
+++ b/toolchain/aarch64-linux-gnu/linux_x86_64/aarch64-linux-gnu-strip
@@ -3,5 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 EXECROOT="$SCRIPT_DIR/../../../../../"
-cd "$EXECROOT"
-external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-strip "$@"
+"$EXECROOT"/external/aarch64_linux_gnu_linux_x86_64/bin/aarch64-linux-gnu-strip "$@"


### PR DESCRIPTION
This change was made to address this issue: https://github.com/bazelbuild/rules_go/issues/2290