### PR TITLE
Make cross-compile toolchain cpu match native toolchain

### DIFF
--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -141,7 +141,7 @@ def _impl(ctx):
         toolchain_identifier = ctx.attr.toolchain_identifier,
         host_system_name = ctx.attr.host_system_name,
         target_system_name = "aarch64-none-linux-gnu",
-        target_cpu = "aarch64-none-linux-gnu",
+        target_cpu = "aarch64", # target_cpu field is used to construct the _solib path
         target_libc = "gcc",
         compiler = ctx.attr.gcc_repo,
         abi_version = "gnu",


### PR DESCRIPTION
The `target_cpu` value is used to construct the installation path for
external shared libraries within each image, so if we set this field
to match the `cpu` field of the native cc toolchain both builds will
put a given library at the same path.
