### PR TITLE
Tolerate running under bazel build and run

### DIFF
--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
@@ -8,7 +8,7 @@ host_lib_path="$(find -L . -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
 # tolerate running under both bazel build and run
 search_base='./external/ubuntu-22.04-arm64-cross/'
 if [[ ! -d $search_base ]]; then
-    search_base='.'
+    search_base='./external/'
 fi
 
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
@@ -5,9 +5,15 @@ set -euo pipefail
 host_lib_path="$(find -L . -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
 [ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
 
+# tolerate running under both bazel build and run
+search_base='./external/ubuntu-22.04-arm64-cross/'
+if [[ ! -d $search_base ]]; then
+    search_base='.'
+fi
+
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's
 # sandbox symlinks, so resolve the actual path where libraries reside:
-libc_realpath="$(realpath "$(find . -name libc.so.6 | head -n1)")" # This is the actual path to libc
+libc_realpath="$(realpath "$(find $search_base -name libc.so.6 | head -n1)")" # This is the actual path to libc
 # Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
@@ -4,7 +4,7 @@ set -euo pipefail
 # tolerate running under both bazel build and run
 search_base='./external/ubuntu-22.04-aarch64-native/'
 if [[ ! -d $search_base ]]; then
-    search_base='.'
+    search_base='./external/'
 fi
 
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# tolerate running under both bazel build and run
+search_base='./external/ubuntu-22.04-aarch64-native/'
+if [[ ! -d $search_base ]]; then
+    search_base='.'
+fi
+
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's
 # sandbox symlinks, so resolve the actual path where libraries reside:
-libc_realpath="$(realpath "$(find . -name libc.so.6 | head -n1)")" # This is the actual path to libc
+libc_realpath="$(realpath "$(find $search_base -name libc.so.6 | head -n1)")" # This is the actual path to libc
 # Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/bkp/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/bkp/x86_64-linux-gnu-gcc
@@ -4,7 +4,7 @@ set -euo pipefail
 # tolerate running under both bazel build and run
 search_base='./external/ubuntu-22.04-arm64-cross/'
 if [[ ! -d $search_base ]]; then
-    search_base='.'
+    search_base='./external/'
 fi
 
 # Required so the host binaries can find shared libraries they need:

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/bkp/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/bkp/x86_64-linux-gnu-gcc
@@ -1,13 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+# tolerate running under both bazel build and run
+search_base='./external/ubuntu-22.04-arm64-cross/'
+if [[ ! -d $search_base ]]; then
+    search_base='.'
+fi
+
 # Required so the host binaries can find shared libraries they need:
-host_lib_path="$(find -L . -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
+host_lib_path="$(find -L $search_base -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
 [ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
 
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's
 # sandbox symlinks, so resolve the actual path where libraries reside:
-libc_realpath="$(realpath "$(find . -name libc.so.6 | head -n1)")" # This is the actual path to libc
+libc_realpath="$(realpath "$(find $search_base -name libc.so.6 | head -n1)")" # This is the actual path to libc
 # Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# tolerate running under both bazel build and run
+search_base='./external/ubuntu-22.04-x86_64-native/'
+if [[ ! -d $search_base ]]; then
+    search_base='.'
+fi
+
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's
 # sandbox symlinks, so resolve the actual path where libraries reside:
-libc_realpath="$(realpath "$(find -L . -name libc.so.6 | head -n1)")" # This is the actual path to libc
+libc_realpath="$(realpath "$(find -L $search_base -name libc.so.6 | head -n1)")" # This is the actual path to libc
 # Remove the filename and usr/x86_64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
@@ -4,7 +4,7 @@ set -euo pipefail
 # tolerate running under both bazel build and run
 search_base='./external/ubuntu-22.04-x86_64-native/'
 if [[ ! -d $search_base ]]; then
-    search_base='.'
+    search_base='./external/'
 fi
 
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's


### PR DESCRIPTION
```
bazel run :refresh_compile_commands
```

will run with the workspace root as the cwd. Detect if we are running from the workspace root and set base of the search path appropriately. Otherwise the `find` will run from the workspace root.

## Testing

Patch internal `WORKSPACE`:

```
AARCH64_LINUX_GNU_COMMIT = "8119127dfc4d2848d012886934e0addc81eff05a"

http_archive(
    name = "aarch64_linux_gnu",
    sha256 = "86fcb7c7b346256e8d86c51c3e34ccfe7fe9653223e1adb329bbc1d056b47855",
    strip_prefix = "bazel-aarch64-linux-gnu-" + AARCH64_LINUX_GNU_COMMIT,
    urls = [
        "https://github.com/agtonomy/bazel-aarch64-linux-gnu/archive/" + AARCH64_LINUX_GNU_COMMIT + ".tar.gz"
    ],
)
```

observe normal bazel builds still work and `bazel run :refresh_compile_commands` isn't hanging on a bunch of `find` commands.