### PR TITLE
Add /bin to PATH for passing gcc wrapper to nvcc

### DIFF
--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure basic shell utilities are available (needed when running under nvcc with stripped PATH)
+export PATH="/bin:$PATH"
+
 # Required so the host binaries can find shared libraries they need:
 host_lib_path="$(find -L . -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
 [ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure basic shell utilities are available (needed when running under nvcc with stripped PATH)
+export PATH="/bin:$PATH"
+
 # tolerate running under both bazel build and run
 search_base='./external/ubuntu-22.04-aarch64-native/'
 if [[ ! -d $search_base ]]; then


### PR DESCRIPTION
When passing the gcc wrapper to `nvcc -ccbin=`, for some reason the PATH gets stripped from ccbin and the wrapper doesn't work (due to calls to find and realpath). This adds /bin to the PATH manually before continuing on in the gcc wrapper