### PR TITLE
Fix arm64 platform selector

### DIFF
--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -34,7 +34,7 @@ platform(
     name = "tegra_jetpack_512",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
         ":jetpack_512",
         ":tegra",
     ],
@@ -45,7 +45,7 @@ platform(
     name = "tegra_jetpack_62",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
         ":jetpack_62",
         ":tegra",
     ],
@@ -56,7 +56,7 @@ platform(
     name = "aarch64_generic",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
         ":generic",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
`aarch64` is the correct selector for a arm64 linux host:

```
alex@haystack:/Users/alex/tmp/bazel-rules-docker-test$ uname -a
Linux haystack 6.17.4-orbstack-00308-g195e9689a04f #1 SMP PREEMPT Fri Oct 24 07:22:34 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
alex@haystack:/Users/alex/tmp/bazel-rules-docker-test$ bazel query --output=build @local_config_platform//:host
# /home/alex/.cache/bazel/_bazel_alex/d0d1628e501376ee10dad567ad617dea/external/local_config_platform/BUILD.bazel:4:9
platform(
  name = "host",
  constraint_values = ["@platforms//cpu:aarch64", "@platforms//os:linux"],
)
# Rule host instantiated at (most recent call last):
#   /home/alex/.cache/bazel/_bazel_alex/d0d1628e501376ee10dad567ad617dea/external/local_config_platform/BUILD.bazel:4:9 in <toplevel>

Loading: 0 packages loaded
```