### PR TITLE
Update http_archives to packages with sanitizer libraries

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -10,30 +10,30 @@ def aarch64_linux_gnu_deps():
     http_archive(
         name = "ubuntu-22.04-arm64-cross",
         build_file = "@aarch64_linux_gnu//toolchain:ubuntu-22.04-arm64-cross.BUILD",
-        sha256 = "655de222f8a0917ca0f88a0160e93736ae69dcf1f018d68b856c8ae6713f71c4",
+        sha256 = "048979d4a99497ea4ce08d57c8bc707d66dbe9c6375a29240c8faef88e76ac23",
         strip_prefix = "ubuntu-22.04-arm64-cross",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-arm64-cross.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-arm64-cross-1.tar.zst",
         ],
     )
 
     http_archive(
         name = "ubuntu-22.04-aarch64-native",
         build_file = "@aarch64_linux_gnu//toolchain:ubuntu-22.04-native.BUILD",
-        sha256 = "4f9a7a99c083d288b00f1120551853155e163196b3474095b3b2c31544f2d69a",
+        sha256 = "6512cce84693447d6489b2f9c44887edc1e91ab733d66c3a376a4a0dd9d2c835",
         strip_prefix = "ubuntu-22.04-aarch64-native",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-aarch64-native.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-aarch64-native-1.tar.zst",
         ],
     )
 
     http_archive(
         name = "ubuntu-22.04-x86_64-native",
         build_file = "@aarch64_linux_gnu//toolchain:ubuntu-22.04-native.BUILD",
-        sha256 = "8d3cfe7ee15ceb690ac9e88be66d419d0dbbb84094767cab34257b8ca8923867",
+        sha256 = "37fdeb9cbc0de5b2b62268fda628301f3c4c26ca0634a77cce19f6b5ac1f81c1",
         strip_prefix = "ubuntu-22.04-x86_64-native",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-x86_64-native.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-x86_64-native-1.tar.zst",
         ],
     )
 


### PR DESCRIPTION
Packages now include libasan, libtsan, and libubsan for each toolchain.