### PR TITLE
Fix path references for gcc subprograms

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   cross-compile:
     name: Cross-compile (x86_64 -> aarch64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -70,7 +70,7 @@ jobs:
 
   native-x86_64:
     name: Native x86_64
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -101,7 +101,7 @@ jobs:
 
   native-arm64:
     name: Native ARM64
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
 
     steps:
       - name: Checkout

--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -9,6 +9,7 @@ def _impl(ctx):
         wrapper_path(ctx, "gcc"),
         wrapper_path(ctx, "ld"),
         wrapper_path(ctx, "ar"),
+        wrapper_path(ctx, "as"),
         wrapper_path(ctx, "cpp"),
         wrapper_path(ctx, "gcov"),
         wrapper_path(ctx, "nm"),
@@ -24,10 +25,13 @@ def _impl(ctx):
         else:
             include_flags.append("external/{}/{}".format(ctx.attr.gcc_repo, path))
 
+    # The config rule lives in the same package as the wrapper scripts, so ctx.label
+    # gives the execroot-relative path to the wrapper directory directly:
     linker_flags = [
+        "-B{}/{}/".format(ctx.label.workspace_root, ctx.label.package),
         "-lstdc++",
         "-lm",
-        "-fuse-ld=gold", # Required for supports_start_end_lib_feature
+        "-fuse-ld=gold",  # Required for supports_start_end_lib_feature
     ]
 
     if ctx.attr.target_cpu == "aarch64":
@@ -120,6 +124,9 @@ def _impl(ctx):
         "-D__TIMESTAMP__=\"redacted\"",
         "-D__TIME__=\"redacted\"",
     ]
+
+    # Tell gcc to look up subprograms like as in the extracted toolchain tar path
+    unfiltered_compile_flags.append("-Bexternal/{}/usr/bin/".format(ctx.attr.gcc_repo))
 
     unfiltered_compile_flags_feature = feature(
         name = "unfiltered_compile_flags",

--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -25,6 +25,8 @@ def _impl(ctx):
         else:
             include_flags.append("external/{}/{}".format(ctx.attr.gcc_repo, path))
 
+    # The -B argument here can be changed to match that in unfiltered_compile_flags once
+    # the toolchain tar includes a symlink from ld.gold to <arch>-linux-gnu-ld.gold.
     # The config rule lives in the same package as the wrapper scripts, so ctx.label
     # gives the execroot-relative path to the wrapper directory directly:
     linker_flags = [

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/BUILD
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/BUILD
@@ -15,9 +15,19 @@ filegroup(
 )
 
 filegroup(
+    name = "as_files",
+    srcs = [
+        "aarch64-linux-gnu-as",
+        "@{}//:as".format(compiler),
+        "@{}//:host_libraries".format(compiler),
+    ],
+)
+
+filegroup(
     name = "compiler_files",
     srcs = [
         "aarch64-linux-gnu-gcc",
+        ":as_files",
         "@{}//:compiler_pieces".format(compiler),
         "@{}//:gcc".format(compiler),
     ],
@@ -28,6 +38,7 @@ filegroup(
     srcs = [
         "aarch64-linux-gnu-gcc",
         "aarch64-linux-gnu-ld",
+        "ld.gold",
         "@{}//:ar".format(compiler),
         "@{}//:compiler_pieces".format(compiler),
         "@{}//:gcc".format(compiler),
@@ -68,7 +79,8 @@ filegroup(
         ":ar_files",
         ":jp62_compiler_files",
         ":jp62_linker_files",
-    ]
+        ":strip_files",
+    ],
 )
 
 filegroup(
@@ -101,7 +113,8 @@ filegroup(
         ":ar_files",
         ":jp512_compiler_files",
         ":jp512_linker_files",
-    ]
+        ":strip_files",
+    ],
 )
 
 filegroup(

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# Required so the host binaries can find shared libraries they need:
+host_lib_path="$(find -L . -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
+[ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
+
+./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-as "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/ld.gold
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/ld.gold
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ld.gold "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/BUILD
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/BUILD
@@ -15,9 +15,18 @@ filegroup(
 )
 
 filegroup(
+    name = "as_files",
+    srcs = [
+        "aarch64-linux-gnu-as",
+        "@{}//:as".format(compiler),
+    ],
+)
+
+filegroup(
     name = "compiler_files",
     srcs = [
         "aarch64-linux-gnu-gcc",
+        ":as_files",
         "@{}//:compiler_pieces".format(compiler),
         "@{}//:gcc".format(compiler),
     ],
@@ -28,6 +37,7 @@ filegroup(
     srcs = [
         "aarch64-linux-gnu-gcc",
         "aarch64-linux-gnu-ld",
+        "ld.gold",
         "@{}//:ar".format(compiler),
         "@{}//:compiler_pieces".format(compiler),
         "@{}//:gcc".format(compiler),
@@ -62,17 +72,18 @@ filegroup(
 filegroup(
     name = "aarch64_all_files",
     srcs = [
-        ":ar_files",
         ":aarch64_compiler_files",
         ":aarch64_linker_files",
-    ]
+        ":ar_files",
+        ":strip_files",
+    ],
 )
 
 filegroup(
     name = "aarch64_compiler_files",
     srcs = [
-        ":compiler_files",
         ":aarch64_compiler_pieces",
+        ":compiler_files",
     ],
 )
 
@@ -99,7 +110,8 @@ filegroup(
         ":ar_files",
         ":jp512_compiler_files",
         ":jp512_linker_files",
-    ]
+        ":strip_files",
+    ],
 )
 
 filegroup(
@@ -131,7 +143,8 @@ cc_linux_gnu_config(
     gcc_repo = compiler,
     gcc_version = "11",
     host_system_name = "linux_aarch64",
-    include_paths = [ # Path order is important to avoid bazel errors about undeclared files:
+    include_paths = [
+        # Path order is important to avoid bazel errors about undeclared files:
         "usr/lib/gcc/aarch64-linux-gnu/11/include/",
         "usr/include/aarch64-linux-gnu/",
         "usr/include/c++/11/",
@@ -149,7 +162,8 @@ cc_linux_gnu_config(
     gcc_repo = compiler,
     gcc_version = "11",
     host_system_name = "linux_aarch64",
-    include_paths = [ # Path order is important to avoid bazel errors about undeclared files:
+    include_paths = [
+        # Path order is important to avoid bazel errors about undeclared files:
         "usr/lib/gcc/aarch64-linux-gnu/11/include/",
         "usr/include/aarch64-linux-gnu/",
         "usr/include/c++/11/",

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ar
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-gcc-ar-11 "$@"
+./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ar "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-as
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-as "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/ld.gold
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/ld.gold
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ld.gold "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/BUILD
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/BUILD
@@ -15,9 +15,18 @@ filegroup(
 )
 
 filegroup(
+    name = "as_files",
+    srcs = [
+        "x86_64-linux-gnu-as",
+        "@{}//:as".format(compiler),
+    ],
+)
+
+filegroup(
     name = "compiler_files",
     srcs = [
         "x86_64-linux-gnu-gcc",
+        ":as_files",
         "@{}//:compiler_pieces".format(compiler),
         "@{}//:gcc".format(compiler),
     ],
@@ -26,6 +35,7 @@ filegroup(
 filegroup(
     name = "linker_files",
     srcs = [
+        "ld.gold",
         "x86_64-linux-gnu-gcc",
         "x86_64-linux-gnu-ld",
         "@{}//:ar".format(compiler),
@@ -63,9 +73,10 @@ filegroup(
     name = "x86_64_all_files",
     srcs = [
         ":ar_files",
+        ":strip_files",
         ":x86_64_compiler_files",
         ":x86_64_linker_files",
-    ]
+    ],
 )
 
 filegroup(
@@ -79,8 +90,8 @@ filegroup(
 filegroup(
     name = "x86_64_linker_files",
     srcs = [
-        ":x86_64_compiler_pieces",
         ":linker_files",
+        ":x86_64_compiler_pieces",
     ],
 )
 
@@ -97,8 +108,6 @@ cc_linux_gnu_config(
     gcc_repo = compiler,
     gcc_version = "11",
     host_system_name = "linux_x86_64",
-    target_system_name = "linux_x86_64",
-    target_cpu = "k8",
     include_paths = [
         "usr/lib/gcc/x86_64-linux-gnu/11/include/",
         "usr/include/x86_64-linux-gnu/",
@@ -108,6 +117,8 @@ cc_linux_gnu_config(
         "external/{}/usr/include/".format("linux-libc-5.15.0-x86_64"),
         "external/{}/usr/include/x86_64-linux-gnu/".format("linux-libc-5.15.0-x86_64"),
     ],
+    target_cpu = "k8",
+    target_system_name = "linux_x86_64",
     toolchain_identifier = "ubuntu-22.04-x86_64-native",
     wrapper_path = "ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-",
 )

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/ld.gold
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/ld.gold
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ld.gold "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ar
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-gcc-ar-11 "$@"
+./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ar "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-as
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-as "$@"


### PR DESCRIPTION
In some cases gcc accidentally fell back to the host `as`, `ld`, and
`strip` executables, use gcc's `-B` argument to set the path prefix to
the external/ location where the toolchain is extracted. Switch from
`gcc-ar-11` to just `gcc-ar` to avoid looking up `ar` in `$PATH`, and
add wrapper scripts for `as` so that bazel can run it directly, and for
`ld.gold` because `gcc` find it by the exact name without the compiler
prefix, and the toolchain tars do not currently include that symlink.
