### PR TITLE
Use absolute paths for gcc subprograms

### DIFF
--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -25,12 +25,7 @@ def _impl(ctx):
         else:
             include_flags.append("external/{}/{}".format(ctx.attr.gcc_repo, path))
 
-    # The -B argument here can be changed to match that in unfiltered_compile_flags once
-    # the toolchain tar includes a symlink from ld.gold to <arch>-linux-gnu-ld.gold.
-    # The config rule lives in the same package as the wrapper scripts, so ctx.label
-    # gives the execroot-relative path to the wrapper directory directly:
     linker_flags = [
-        "-B{}/{}/".format(ctx.label.workspace_root, ctx.label.package),
         "-lstdc++",
         "-lm",
         "-fuse-ld=gold",  # Required for supports_start_end_lib_feature
@@ -126,9 +121,6 @@ def _impl(ctx):
         "-D__TIMESTAMP__=\"redacted\"",
         "-D__TIME__=\"redacted\"",
     ]
-
-    # Tell gcc to look up subprograms like as in the extracted toolchain tar path
-    unfiltered_compile_flags.append("-Bexternal/{}/usr/bin/".format(ctx.attr.gcc_repo))
 
     unfiltered_compile_flags_feature = feature(
         name = "unfiltered_compile_flags",

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+
 # Required so the host binaries can find shared libraries they need:
-host_lib_path="$(find -L . -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
+host_lib_path="$(find -L "${external_dir}" -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
 [ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ar "$@"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+
 # Required so the host binaries can find shared libraries they need:
-host_lib_path="$(find -L . -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
+host_lib_path="$(find -L "${external_dir}" -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
 [ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-as "$@"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-cpp
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-cpp
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-cpp-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-cpp-11" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
@@ -5,15 +5,12 @@ set -euo pipefail
 export PATH="/bin:$PATH"
 
 
-search_base='./external/ubuntu-22.04-arm64-cross/'
-if [[ ! -d "$search_base" ]]; then
-    # If this is `bazel run` or some module uses chdir, locate the search base relative to this script:
-    search_base="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/../../../../"
-fi
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+external_dir="$(cd "${script_dir}/../../../../" && pwd)"
 
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's
 # sandbox symlinks, so resolve the actual path where libraries reside:
-libc_realpath="$(realpath "$(find "$search_base" -name libc.so.6 | head -n1)")" # This is the actual path to libc
+libc_realpath="$(realpath "$(find "${external_dir}/ubuntu-22.04-arm64-cross/" -name libc.so.6 | head -n1)")" # This is the actual path to libc
 # Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 
@@ -26,4 +23,8 @@ host_lib_path="$(find -L "$sysroot" -name 'libopcodes*.so' -printf "%h\n" | head
 # the command line as DT_NEEDED, which is required to make ld.so use the RPATH entries
 # to find those libraries:
 
-"$sysroot/usr/bin/aarch64-linux-gnu-gcc-11" -Wl,--no-as-needed "$@" --sysroot="$sysroot"
+"$sysroot/usr/bin/aarch64-linux-gnu-gcc-11" \
+    -Wl,--no-as-needed \
+    "-B${sysroot}/usr/bin/" \
+    "-B${script_dir}/" \
+    "$@" --sysroot="$sysroot"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcov
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcov
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-gcov-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-gcov-11" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ld
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ld
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ld "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ld" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-nm
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-nm
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-nm "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-nm" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-objcopy
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-objcopy
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-objcopy "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-objcopy" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-objdump
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-objdump
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-objdump "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-objdump" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-strip
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-strip
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-strip "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-strip" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/ld.gold
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/ld.gold
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ld.gold "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ld.gold" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ar
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ar "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-as
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-as "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-cpp
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-cpp
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-cpp-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-cpp-11" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
@@ -4,15 +4,13 @@ set -euo pipefail
 # Ensure basic shell utilities are available (needed when running under nvcc with stripped PATH)
 export PATH="/bin:$PATH"
 
-search_base='./external/ubuntu-22.04-aarch64-native/'
-if [[ ! -d $search_base ]]; then
-    # If this is `bazel run` or some module uses chdir, locate the search base relative to this script:
-    search_base="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/../../../../"
-fi
+# Always resolve from script location so paths work when a caller (e.g. rules_go) chdirs:
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+external_dir="$(cd "${script_dir}/../../../../" && pwd)"
 
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's
 # sandbox symlinks, so resolve the actual path where libraries reside:
-libc_realpath="$(realpath "$(find "$search_base" -name libc.so.6 | head -n1)")" # This is the actual path to libc
+libc_realpath="$(realpath "$(find "${external_dir}/ubuntu-22.04-aarch64-native/" -name libc.so.6 | head -n1)")" # This is the actual path to libc
 # Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 
@@ -21,4 +19,8 @@ sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 # the command line as DT_NEEDED, which is required to make ld.so use the RPATH entries
 # to find those libraries:
 
-"$sysroot/usr/bin/aarch64-linux-gnu-gcc-11" -Wl,--no-as-needed "$@" --sysroot="$sysroot"
+"$sysroot/usr/bin/aarch64-linux-gnu-gcc-11" \
+    -Wl,--no-as-needed \
+    "-B${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/" \
+    "-B${script_dir}/" \
+    "$@" --sysroot="$sysroot"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcov
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcov
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-gcov-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-gcov-11" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ld
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ld
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ld "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ld" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-nm
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-nm
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-gcc-nm-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-gcc-nm-11" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-objcopy
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-objcopy
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-objcopy "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-objcopy" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-objdump
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-objdump
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-objdump "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-objdump" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-strip
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-strip
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-strip "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-strip" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/ld.gold
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/ld.gold
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ld.gold "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ld.gold" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/ld.gold
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/ld.gold
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ld.gold "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ld.gold" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ar
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ar "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-as
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-as "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-cpp
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-cpp
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-cpp-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-cpp-11" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
@@ -1,15 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-search_base='./external/ubuntu-22.04-x86_64-native/'
-if [[ ! -d $search_base ]]; then
-    # If this is `bazel run` or some module uses chdir, locate the search base relative to this script:
-    search_base="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/../../../../"
-fi
+# Always resolve from script location so paths work when a caller (e.g. rules_go) chdirs:
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+external_dir="$(cd "${script_dir}/../../../../" && pwd)"
 
 # ld (at least built and configured the way Ubuntu does,) doesn't work well with bazel's
 # sandbox symlinks, so resolve the actual path where libraries reside:
-libc_realpath="$(realpath "$(find -L "$search_base" -name libc.so.6 | head -n1)")" # This is the actual path to libc
+libc_realpath="$(realpath "$(find -L "${external_dir}/ubuntu-22.04-x86_64-native/" -name libc.so.6 | head -n1)")" # This is the actual path to libc
 # Remove the filename and usr/x86_64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 
@@ -18,4 +16,8 @@ sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 # the command line as DT_NEEDED, which is required to make ld.so use the RPATH entries
 # to find those libraries:
 
-"$sysroot/usr/bin/x86_64-linux-gnu-gcc-11" -Wl,--no-as-needed "$@" --sysroot="$sysroot"
+"$sysroot/usr/bin/x86_64-linux-gnu-gcc-11" \
+    -Wl,--no-as-needed \
+    "-B${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/" \
+    "-B${script_dir}/" \
+    "$@" --sysroot="$sysroot"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcov
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcov
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-gcov-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-gcov-11" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ld
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ld
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ld "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ld" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-nm
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-nm
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-gcc-nm-11 "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-gcc-nm-11" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-objcopy
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-objcopy
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-objcopy "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-objcopy" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-objdump
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-objdump
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-objdump "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-objdump" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-strip
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-strip
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-./external/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-strip "$@"
+external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-strip" "$@"


### PR DESCRIPTION
The `-B` paths in the last commit are necessarily relative, and so do not
work for cases where `gcc` is called from a directory other than the
sandbox root (`rules_go` specifically does this.)

Remove the `-B` flags from `config.bzl`, determine the absolute path for
all binary wrappers, and specify absolute `-B` paths in the `gcc` wrapper.