### PR TITLE
Explicitly add sanitizer shared library rpath

### DIFF
--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
@@ -19,8 +19,12 @@ sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 # the command line as DT_NEEDED, which is required to make ld.so use the RPATH entries
 # to find those libraries:
 
+sanitizer_rpath=()
+[[ "$*" == *-fsanitize=* ]] && sanitizer_rpath=("-Wl,-rpath,${sysroot}/usr/lib/aarch64-linux-gnu/")
+
 "$sysroot/usr/bin/aarch64-linux-gnu-gcc-11" \
     -Wl,--no-as-needed \
     "-B${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/" \
+    "${sanitizer_rpath[@]}" \
     "-B${script_dir}/" \
     "$@" --sysroot="$sysroot"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
@@ -16,8 +16,12 @@ sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 # the command line as DT_NEEDED, which is required to make ld.so use the RPATH entries
 # to find those libraries:
 
+sanitizer_rpath=()
+[[ "$*" == *-fsanitize=* ]] && sanitizer_rpath=("-Wl,-rpath,${sysroot}/usr/lib/x86_64-linux-gnu/")
+
 "$sysroot/usr/bin/x86_64-linux-gnu-gcc-11" \
     -Wl,--no-as-needed \
     "-B${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/" \
+    "${sanitizer_rpath[@]}" \
     "-B${script_dir}/" \
     "$@" --sysroot="$sysroot"


### PR DESCRIPTION
Bazel usually handles rpath entries to find shared libraries within the
sandbox, but the sanitizer libraries are linked implicitly by gcc, so
the standard bazel functions do not work, and we have to add the rpath
argument manually. To avoid adding unnecessary paths to non-sanitizer
binaries only add the rpath argument when `-fsanitizer` is present on
the command line.
