### PR TITLE
Add /bin and /usr/bin to x86_64 gcc's PATH

### DIFF
--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure basic shell utilities are available (needed when running under nvcc
+# with stripped PATH). Matches the same fix in the aarch64 cross wrapper.
+export PATH="/bin:/usr/bin:$PATH"
+
 # Always resolve from script location so paths work when a caller (e.g. rules_go) chdirs:
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 external_dir="$(cd "${script_dir}/../../../../" && pwd)"


### PR DESCRIPTION
Same as #8 did for the aarch64 native toolchain, to support nvcc on
x86_64.
