### PR TITLE
Bundle almost all host libraries to support most Linux hosts

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -10,30 +10,30 @@ def aarch64_linux_gnu_deps():
     http_archive(
         name = "ubuntu-22.04-arm64-cross",
         build_file = "@aarch64_linux_gnu//toolchain:ubuntu-22.04-arm64-cross.BUILD",
-        sha256 = "048979d4a99497ea4ce08d57c8bc707d66dbe9c6375a29240c8faef88e76ac23",
+        sha256 = "f2cca1cb85f239ec48a20ebefa7868ca79d83bd12489f3ebdbcd48d583cfb5d5",
         strip_prefix = "ubuntu-22.04-arm64-cross",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-arm64-cross-1.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain-next/ubuntu-22.04-arm64-cross-2.tar.zst",
         ],
     )
 
     http_archive(
         name = "ubuntu-22.04-aarch64-native",
         build_file = "@aarch64_linux_gnu//toolchain:ubuntu-22.04-native.BUILD",
-        sha256 = "6512cce84693447d6489b2f9c44887edc1e91ab733d66c3a376a4a0dd9d2c835",
+        sha256 = "2b009b59377e21581d67b0f5d6f314a0ef2249b1941b4fca03685bfc3facf8de",
         strip_prefix = "ubuntu-22.04-aarch64-native",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-aarch64-native-1.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain-next/ubuntu-22.04-aarch64-native-2.tar.zst",
         ],
     )
 
     http_archive(
         name = "ubuntu-22.04-x86_64-native",
         build_file = "@aarch64_linux_gnu//toolchain:ubuntu-22.04-native.BUILD",
-        sha256 = "37fdeb9cbc0de5b2b62268fda628301f3c4c26ca0634a77cce19f6b5ac1f81c1",
+        sha256 = "342fc43d0fa977edcb4e9d6840a0c289bc09123327eff05c6a399964a0bfaaa2",
         strip_prefix = "ubuntu-22.04-x86_64-native",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-x86_64-native-1.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain-next/ubuntu-22.04-x86_64-native-2.tar.zst",
         ],
     )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -13,7 +13,7 @@ def aarch64_linux_gnu_deps():
         sha256 = "f2cca1cb85f239ec48a20ebefa7868ca79d83bd12489f3ebdbcd48d583cfb5d5",
         strip_prefix = "ubuntu-22.04-arm64-cross",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain-next/ubuntu-22.04-arm64-cross-2.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-arm64-cross-2.tar.zst",
         ],
     )
 
@@ -23,7 +23,7 @@ def aarch64_linux_gnu_deps():
         sha256 = "2b009b59377e21581d67b0f5d6f314a0ef2249b1941b4fca03685bfc3facf8de",
         strip_prefix = "ubuntu-22.04-aarch64-native",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain-next/ubuntu-22.04-aarch64-native-2.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-aarch64-native-2.tar.zst",
         ],
     )
 
@@ -33,7 +33,7 @@ def aarch64_linux_gnu_deps():
         sha256 = "342fc43d0fa977edcb4e9d6840a0c289bc09123327eff05c6a399964a0bfaaa2",
         strip_prefix = "ubuntu-22.04-x86_64-native",
         urls = [
-            "http://dependency-mirror.s3.amazonaws.com/toolchain-next/ubuntu-22.04-x86_64-native-2.tar.zst",
+            "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-x86_64-native-2.tar.zst",
         ],
     )
 

--- a/toolchain/ubuntu-22.04-arm64-cross.BUILD
+++ b/toolchain/ubuntu-22.04-arm64-cross.BUILD
@@ -93,7 +93,10 @@ filegroup(
 # on the host system:
 filegroup(
     name = "host_libraries",
-    srcs = glob(["usr/lib/x86_64-linux-gnu/*"]),
+    srcs = glob([
+        "host-libs/**",
+        "usr/lib/x86_64-linux-gnu/*",
+    ]),
 )
 
 # collection of executables.

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
@@ -3,8 +3,11 @@ set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 
-# Required so the host binaries can find shared libraries they need:
-host_lib_path="$(find -L "${external_dir}" -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
-[ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
+# Required so the host binaries can find shared libraries they need.
+# Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
+# x86_64 runtime libs there, and unlike the native archives this path has no x86_64
+# libc.so.6, so there is no glibc version mixing risk.
+[ -d "${sysroot}/host-libs" ] && \
+    export LD_LIBRARY_PATH="${sysroot}/host-libs:${sysroot}/usr/lib/x86_64-linux-gnu"
 
 exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
@@ -3,15 +3,10 @@ set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 
-libc_realpath="$(realpath "$(find "${external_dir}/ubuntu-22.04-arm64-cross/" -name libc.so.6 | head -n1)")" # This is the actual path to libc
-# Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
-sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
-
 # Required so the host binaries can find shared libraries they need.
 # Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
 # x86_64 runtime libs there, and unlike the native archives this path has no x86_64
 # libc.so.6, so there is no glibc version mixing risk.
-[ -d "${sysroot}/host-libs" ] && \
-    export LD_LIBRARY_PATH="${sysroot}/host-libs:${sysroot}/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-arm64-cross/host-libs:${external_dir}/ubuntu-22.04-arm64-cross/usr/lib/x86_64-linux-gnu"
 
 exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
@@ -3,6 +3,10 @@ set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 
+libc_realpath="$(realpath "$(find "${external_dir}/ubuntu-22.04-arm64-cross/" -name libc.so.6 | head -n1)")" # This is the actual path to libc
+# Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
+sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
+
 # Required so the host binaries can find shared libraries they need.
 # Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
 # x86_64 runtime libs there, and unlike the native archives this path has no x86_64

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
@@ -3,8 +3,11 @@ set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 
-# Required so the host binaries can find shared libraries they need:
-host_lib_path="$(find -L "${external_dir}" -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
-[ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
+# Required so the host binaries can find shared libraries they need.
+# Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
+# x86_64 runtime libs there, and unlike the native archives this path has no x86_64
+# libc.so.6, so there is no glibc version mixing risk.
+[ -d "${sysroot}/host-libs" ] && \
+    export LD_LIBRARY_PATH="${sysroot}/host-libs:${sysroot}/usr/lib/x86_64-linux-gnu"
 
 exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
@@ -3,15 +3,10 @@ set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 
-libc_realpath="$(realpath "$(find "${external_dir}/ubuntu-22.04-arm64-cross/" -name libc.so.6 | head -n1)")" # This is the actual path to libc
-# Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
-sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
-
 # Required so the host binaries can find shared libraries they need.
 # Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
 # x86_64 runtime libs there, and unlike the native archives this path has no x86_64
 # libc.so.6, so there is no glibc version mixing risk.
-[ -d "${sysroot}/host-libs" ] && \
-    export LD_LIBRARY_PATH="${sysroot}/host-libs:${sysroot}/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-arm64-cross/host-libs:${external_dir}/ubuntu-22.04-arm64-cross/usr/lib/x86_64-linux-gnu"
 
 exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
@@ -3,6 +3,10 @@ set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 
+libc_realpath="$(realpath "$(find "${external_dir}/ubuntu-22.04-arm64-cross/" -name libc.so.6 | head -n1)")" # This is the actual path to libc
+# Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
+sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
+
 # Required so the host binaries can find shared libraries they need.
 # Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
 # x86_64 runtime libs there, and unlike the native archives this path has no x86_64

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
@@ -14,9 +14,12 @@ libc_realpath="$(realpath "$(find "${external_dir}/ubuntu-22.04-arm64-cross/" -n
 # Remove the filename and usr/aarch64-linux-gnu/lib to get the sysroot:
 sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 
-# Required so the host binaries can find shared libraries they need:
-host_lib_path="$(find -L "$sysroot" -name 'libopcodes*.so' -printf "%h\n" | head -n1)"
-[ "$host_lib_path" ] && export LD_LIBRARY_PATH="$host_lib_path"
+# Required so the host binaries can find shared libraries they need.
+# Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
+# x86_64 runtime libs there, and unlike the native archives this path has no x86_64
+# libc.so.6, so there is no glibc version mixing risk.
+[ -d "${sysroot}/host-libs" ] && \
+    export LD_LIBRARY_PATH="${sysroot}/host-libs:${sysroot}/usr/lib/x86_64-linux-gnu"
 
 # Due to https://github.com/bazelbuild/bazel/issues/16222 this is the only spot we can add
 # the --no-as-needed ld flag to make the final binary list every shared library provided on

--- a/toolchain/ubuntu-22.04-native.BUILD
+++ b/toolchain/ubuntu-22.04-native.BUILD
@@ -95,6 +95,12 @@ filegroup(
     ]),
 )
 
+# Shared libraries required to execute compiler binaries on the host system:
+filegroup(
+    name = "host_libraries",
+    srcs = glob(["host-libs/**"]),
+)
+
 # collection of executables.
 filegroup(
     name = "compiler_components",

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/BUILD
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/BUILD
@@ -19,6 +19,7 @@ filegroup(
     srcs = [
         "aarch64-linux-gnu-as",
         "@{}//:as".format(compiler),
+        "@{}//:host_libraries".format(compiler),
     ],
 )
 
@@ -41,6 +42,7 @@ filegroup(
         "@{}//:ar".format(compiler),
         "@{}//:compiler_pieces".format(compiler),
         "@{}//:gcc".format(compiler),
+        "@{}//:host_libraries".format(compiler),
         "@{}//:ld".format(compiler),
     ],
 )
@@ -50,6 +52,7 @@ filegroup(
     srcs = [
         "aarch64-linux-gnu-ar",
         "@{}//:ar".format(compiler),
+        "@{}//:host_libraries".format(compiler),
     ],
 )
 

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-ar
@@ -2,4 +2,9 @@
 set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+
+# Required so the host binaries can find shared libraries they need:
+[ -d "${external_dir}/ubuntu-22.04-aarch64-native/host-libs" ] && \
+    export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-aarch64-native/host-libs"
+
 exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-as
@@ -2,4 +2,9 @@
 set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+
+# Required so the host binaries can find shared libraries they need:
+[ -d "${external_dir}/ubuntu-22.04-aarch64-native/host-libs" ] && \
+    export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-aarch64-native/host-libs"
+
 exec "${external_dir}/ubuntu-22.04-aarch64-native/usr/bin/aarch64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_aarch64/aarch64-linux-gnu-gcc
@@ -19,6 +19,9 @@ sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 # the command line as DT_NEEDED, which is required to make ld.so use the RPATH entries
 # to find those libraries:
 
+# Required so the host binaries can find shared libraries they need:
+[ -d "${sysroot}/host-libs" ] && export LD_LIBRARY_PATH="${sysroot}/host-libs"
+
 sanitizer_rpath=()
 [[ "$*" == *-fsanitize=* ]] && sanitizer_rpath=("-Wl,-rpath,${sysroot}/usr/lib/aarch64-linux-gnu/")
 

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/BUILD
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/BUILD
@@ -19,6 +19,7 @@ filegroup(
     srcs = [
         "x86_64-linux-gnu-as",
         "@{}//:as".format(compiler),
+        "@{}//:host_libraries".format(compiler),
     ],
 )
 
@@ -41,6 +42,7 @@ filegroup(
         "@{}//:ar".format(compiler),
         "@{}//:compiler_pieces".format(compiler),
         "@{}//:gcc".format(compiler),
+        "@{}//:host_libraries".format(compiler),
         "@{}//:ld".format(compiler),
     ],
 )
@@ -50,6 +52,7 @@ filegroup(
     srcs = [
         "x86_64-linux-gnu-ar",
         "@{}//:ar".format(compiler),
+        "@{}//:host_libraries".format(compiler),
     ],
 )
 

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-ar
@@ -2,4 +2,9 @@
 set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+
+# Required so the host binaries can find shared libraries they need:
+[ -d "${external_dir}/ubuntu-22.04-x86_64-native/host-libs" ] && \
+    export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-x86_64-native/host-libs"
+
 exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-as
@@ -2,4 +2,9 @@
 set -euo pipefail
 
 external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+
+# Required so the host binaries can find shared libraries they need:
+[ -d "${external_dir}/ubuntu-22.04-x86_64-native/host-libs" ] && \
+    export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-x86_64-native/host-libs"
+
 exec "${external_dir}/ubuntu-22.04-x86_64-native/usr/bin/x86_64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-native/linux_x86_64/x86_64-linux-gnu-gcc
@@ -20,6 +20,9 @@ sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 # the command line as DT_NEEDED, which is required to make ld.so use the RPATH entries
 # to find those libraries:
 
+# Required so the host binaries can find shared libraries they need:
+[ -d "${sysroot}/host-libs" ] && export LD_LIBRARY_PATH="${sysroot}/host-libs"
+
 sanitizer_rpath=()
 [[ "$*" == *-fsanitize=* ]] && sanitizer_rpath=("-Wl,-rpath,${sysroot}/usr/lib/x86_64-linux-gnu/")
 


### PR DESCRIPTION
A few libraries have still been silently provided by the host OS to
toolchain executables, which causes problems on distros which diverge
from Ubuntu 22.04 and do not provide the same versions of those
libraries.

Fix that by bundling every shared library linked by the toolchains
other than `ld-linux.so`, and modify the relevant wrapper scripts to put
the bundled library paths in LD_LIBRARY_PATH. The host-libs subdirectory
is used to limit how many libraries are added to the path.
