### PR TITLE
Cross-compile: Remove unnecessary host-libs path and fix checksum

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -10,7 +10,7 @@ def aarch64_linux_gnu_deps():
     http_archive(
         name = "ubuntu-22.04-arm64-cross",
         build_file = "@aarch64_linux_gnu//toolchain:ubuntu-22.04-arm64-cross.BUILD",
-        sha256 = "f2cca1cb85f239ec48a20ebefa7868ca79d83bd12489f3ebdbcd48d583cfb5d5",
+        sha256 = "14d7e4f9cc87a3320033062a6978d848e5702186c9478b73cfb1c03744302b5b",
         strip_prefix = "ubuntu-22.04-arm64-cross",
         urls = [
             "http://dependency-mirror.s3.amazonaws.com/toolchain/ubuntu-22.04-arm64-cross-2.tar.zst",

--- a/toolchain/ubuntu-22.04-arm64-cross.BUILD
+++ b/toolchain/ubuntu-22.04-arm64-cross.BUILD
@@ -93,10 +93,7 @@ filegroup(
 # on the host system:
 filegroup(
     name = "host_libraries",
-    srcs = glob([
-        "host-libs/**",
-        "usr/lib/x86_64-linux-gnu/*",
-    ]),
+    srcs = glob(["usr/lib/x86_64-linux-gnu/*"]),
 )
 
 # collection of executables.

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-ar
@@ -7,6 +7,6 @@ external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 # Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
 # x86_64 runtime libs there, and unlike the native archives this path has no x86_64
 # libc.so.6, so there is no glibc version mixing risk.
-export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-arm64-cross/host-libs:${external_dir}/ubuntu-22.04-arm64-cross/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-arm64-cross/usr/lib/x86_64-linux-gnu"
 
 exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-ar" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-as
@@ -7,6 +7,6 @@ external_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
 # Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
 # x86_64 runtime libs there, and unlike the native archives this path has no x86_64
 # libc.so.6, so there is no glibc version mixing risk.
-export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-arm64-cross/host-libs:${external_dir}/ubuntu-22.04-arm64-cross/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH="${external_dir}/ubuntu-22.04-arm64-cross/usr/lib/x86_64-linux-gnu"
 
 exec "${external_dir}/ubuntu-22.04-arm64-cross/usr/bin/aarch64-linux-gnu-as" "$@"

--- a/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
+++ b/toolchain/ubuntu-22.04-arm64-cross/linux_x86_64/aarch64-linux-gnu-gcc
@@ -18,8 +18,7 @@ sysroot="$(realpath "$(dirname "$libc_realpath")/../../../")"
 # Include usr/lib/x86_64-linux-gnu/ alongside host-libs/: the cross packages deposit
 # x86_64 runtime libs there, and unlike the native archives this path has no x86_64
 # libc.so.6, so there is no glibc version mixing risk.
-[ -d "${sysroot}/host-libs" ] && \
-    export LD_LIBRARY_PATH="${sysroot}/host-libs:${sysroot}/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH="${sysroot}/usr/lib/x86_64-linux-gnu"
 
 # Due to https://github.com/bazelbuild/bazel/issues/16222 this is the only spot we can add
 # the --no-as-needed ld flag to make the final binary list every shared library provided on


### PR DESCRIPTION
This commit should have made it onto my last PR, the cross toolchain
doesn't ship libc so the required runtime libraries do not need to be
isolated in the host-libs path as with the native toolchains.
